### PR TITLE
Optimize header video loading

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -1,6 +1,6 @@
 <header>
   <div class="hero">
-    <video id="headerVideo" class="header-video" src="assets/river-flowing.mp4" autoplay muted playsinline></video>
+    <video id="headerVideo" class="header-video" src="assets/river-flowing.mp4" autoplay muted playsinline preload="none" poster="assets/logo-500px.png"></video>
     <div class="overlay">
       <img src="assets/logo-500px.png" alt="SmoothFlow Automations logo" class="logo" width="500" height="500" loading="lazy">
       <h1>SmoothFlow Automations</h1>

--- a/js/header.js
+++ b/js/header.js
@@ -4,6 +4,11 @@
 function initHeader() {
   const video = document.getElementById('headerVideo');
   if (video) {
+    const isSmallScreen = window.matchMedia('(max-width: 768px)').matches;
+    if (isSmallScreen) {
+      video.removeAttribute('autoplay');
+      video.pause();
+    }
     video.addEventListener('ended', function () {
       video.pause();
       video.currentTime = video.duration; // freeze on last frame


### PR DESCRIPTION
## Summary
- avoid preloading header video
- set a poster image
- stop video autoplay on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686af6612a4c8333be655390412be3bc